### PR TITLE
Fix date generation

### DIFF
--- a/pymarketcap/core.py
+++ b/pymarketcap/core.py
@@ -404,8 +404,8 @@ class Pymarketcap(object):
 
         url = self.urls["web"] + 'currencies/' + currency + '/historical-data/'
         url += '?start={}&end={}'.format(
-            str(start.year) + str(start.month) + str(start.day),
-            str(end.year) + str(end.month) + str(end.day)
+            str(start.year) + "%02d" % start.month + "%02d" % start.day,
+            str(end.year) + "%02d" % end.month + "%02d" % end.day
         )
         html = self._html(url)
 


### PR DESCRIPTION
Fix the date generation, some time we obtain the "No data was found for the selected time period.", because the date is incorrectly generated. example "2018111" instead "20180111"