### PR TITLE
Include formatted name, website and twitter links for exchanges.

### DIFF
--- a/pymarketcap/core.py
+++ b/pymarketcap/core.py
@@ -580,7 +580,7 @@ class Pymarketcap(object):
                 response.append(exch)
         return response
 
-    def exchange(self, name):
+    def exchange(self, name, include_metadata=False):
         """Obtain data from a exchange passed as argument
 
         Example:
@@ -596,14 +596,17 @@ class Pymarketcap(object):
         html = self._html(url)
 
         marks = html.find('table').find_all('tr')
-        response = {
-            'markets': []
-        }
 
+        response = []
 
-        response['formatted_name'] = self._select(html, 'h1.text-large')
-        response['website'] = self._select(html, 'span[title=Website] + a', 'href')
-        response['twitter'] = self._select(html, 'img[alt=Twitter] + a', 'href')
+        if include_metadata:
+            response = {
+                'markets': []
+            }
+
+            response['formatted_name'] = self._select(html, 'h1.text-large')
+            response['website'] = self._select(html, 'span[title=Website] + a', 'href')
+            response['twitter'] = self._select(html, 'img[alt=Twitter] + a', 'href')
 
         for m in marks[1:]:
             _childs, childs = (m.contents, [])
@@ -633,7 +636,9 @@ class Pymarketcap(object):
                           'volume_24h_usd': volume_24h_usd,
                           'price_usd': price_usd,
                           'perc_volume': perc_volume}
-            response['markets'].append(indicators)
+            markets = response['markets'] if include_metadata else response
+
+            markets.append(indicators)
 
         return response
 

--- a/tests/units/test_scraper.py
+++ b/tests/units/test_scraper.py
@@ -119,6 +119,8 @@ class TestScraperCoinmarketcap(unittest.TestCase):
 
     def test_exchange(self):
         actual = self.coinmarketcap.exchange(self.config.EXCHANGE)
+        actual_w_metadata = self.coinmarketcap.exchange(
+            self.config.EXCHANGE, include_metadata=True)
 
         value_types= {'formatted_name': str,
                       'website': str,
@@ -132,12 +134,14 @@ class TestScraperCoinmarketcap(unittest.TestCase):
                        'name': str,
                        'perc_volume': Decimal}
 
-        self.assertIs(type(actual), dict)
+        self.assertIs(type(actual), list)
 
-        for key, value in actual.items():
+        self.assertIs(type(actual_w_metadata), dict)
+
+        for key, value in actual_w_metadata.items():
             self.assertIs(type(value), value_types[key])
 
-        for market in actual['markets']:
+        for market in actual:
             self.assertIs(type(market), dict)
             for key, value in market.items():
                 self.assertIs(type(value), markets_value_types[key])

--- a/tests/units/test_scraper.py
+++ b/tests/units/test_scraper.py
@@ -119,18 +119,28 @@ class TestScraperCoinmarketcap(unittest.TestCase):
 
     def test_exchange(self):
         actual = self.coinmarketcap.exchange(self.config.EXCHANGE)
-        value_types = {'market': str,
+
+        value_types= {'formatted_name': str,
+                      'website': str,
+                      'twitter': str,
+                      'markets': list}
+
+        markets_value_types = {'market': str,
                        'price_usd': Decimal,
                        'rank': int,
                        'volume_24h_usd': int,
                        'name': str,
                        'perc_volume': Decimal}
 
-        self.assertIs(type(actual), list)
-        for market in actual:
+        self.assertIs(type(actual), dict)
+
+        for key, value in actual.items():
+            self.assertIs(type(value), value_types[key])
+
+        for market in actual['markets']:
             self.assertIs(type(market), dict)
             for key, value in market.items():
-                self.assertIs(type(value), value_types[key])
+                self.assertIs(type(value), markets_value_types[key])
 
     def test_exchanges(self):
         actual = self.coinmarketcap.exchanges()
@@ -149,6 +159,8 @@ class TestScraperCoinmarketcap(unittest.TestCase):
                 if key in ('rank', 'volume_usd'):
                     self.assertIs(type(value), int)
                 elif key == 'name':
+                    self.assertIs(type(value), str)
+                elif key == 'formatted_name':
                     self.assertIs(type(value), str)
                 elif key == 'markets':
                     self.assertIs(type(value), list)


### PR DESCRIPTION
I realize that this might break some projects, since I have changed the exchange function to return a dict instead of a list. I couldn't see a more elegant approach while also keeping exchange metadata (formatted name, website, etc).

It also feels more 'right' this way, since the markets are _part_ of the exchange page, not the only thing there. Let me know what you think.